### PR TITLE
Add tool verification workflow

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -1,0 +1,37 @@
+name: Tool Checks
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  verify-tools:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Bandit
+        run: pip install bandit
+
+      - name: Install Go-Task
+        run: |
+          curl -sL https://taskfile.dev/install.sh | sh -s -- -b /usr/local/bin
+
+      - name: Install Vagrant
+        run: |
+          sudo apt-get update && sudo apt-get install -y gnupg software-properties-common
+          curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+          sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+          sudo apt-get update
+          sudo apt-get install -y vagrant
+
+      - name: Run Bandit
+        run: bandit -r ./src
+
+      - name: Check Go-Task
+        run: task --version
+
+      - name: Check Vagrant
+        run: vagrant --version


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs Vagrant, Bandit and Go-Task
- run Bandit on the `src` directory and verify each tool's version

## Testing
- `pre-commit run --files .github/workflows/tools.yml`
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686591ecde448331bfbb6eedcf441ba6