### PR TITLE
Add developer setup guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,11 +53,16 @@ conda env create -f environment.yml  # works with `mamba` too
 conda activate SALib
 ```
 
-Finally, you can install SALib in editable mode in your environment:
+Finally, install SALib along with the development dependencies and set up
+pre-commit:
 
 ```sh
-pip install -e .
+pip install -e .[dev]
+pre-commit install
+pytest
 ```
+
+See `docs/developer_setup.md` for a quick setup summary.
 
 ### Fixing a Bug
 

--- a/docs/developer_setup.md
+++ b/docs/developer_setup.md
@@ -1,0 +1,32 @@
+# Developer Setup
+
+This guide provides the basic steps to set up a development environment for SALib.
+
+1. **Clone the repository**
+
+```bash
+git clone https://github.com/SALib/SALib.git
+cd SALib
+```
+
+2. **Create the conda environment**
+
+Use `conda` (or `mamba`) to create the environment specified in `environment.yml`:
+
+```bash
+conda env create -f environment.yml  # works with mamba too
+```
+
+3. **Activate the environment and install SALib**
+
+```bash
+conda activate SALib
+pip install -e .[dev]
+```
+
+4. **Install pre-commit hooks and run the tests**
+
+```bash
+pre-commit install
+pytest
+```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,6 +62,7 @@ For Developers
 
     API <api>
     Developers Guide <developers_guide>
+    Developer Setup <developer_setup>
     Changes <changelog>
     Complete Module Reference <api/modules>
 


### PR DESCRIPTION
## Summary
- document how to create the SALib dev environment and run tests
- link the new page from docs index
- mention developer setup guide in CONTRIBUTING

## Testing
- `pre-commit run --files docs/developer_setup.md docs/index.rst CONTRIBUTING.md`
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68659e3d37548331a8657ea58313fa7b