### PR TITLE
Fix duplicate keyword in interactive violin plot

### DIFF
--- a/src/SALib/plotting/interactive.py
+++ b/src/SALib/plotting/interactive.py
@@ -156,7 +156,6 @@ def raincloud_interactive(
                 orientation=orientation,
                 points=False,
                 legendgroup=cat_name,
-                name=cat_name, # Name for legend item
                 showlegend= (i==0), # Show legend only for the first category's violin
                 scalegroup=cat_name,
                 meanline_visible=False,


### PR DESCRIPTION
## Summary
- remove duplicate `name` argument in plotting `go.Violin`
- run tests to show previous SyntaxError in `interactive.py` is resolved (tests still fail elsewhere)

## Testing
- `pytest -q` *(fails: SyntaxError in sobol_correlated.py)*

------
https://chatgpt.com/codex/tasks/task_e_686855203ec483319b8889642b7fd226