### PR TITLE
Remove stray import in correlated Sobol sampler

### DIFF
--- a/src/SALib/sample/sobol_correlated.py
+++ b/src/SALib/sample/sobol_correlated.py
@@ -5,9 +5,7 @@ sensitivity analysis, based on constructing sample matrices A, B, C_i, and D_i
 from base correlated samples.
 """
 import numpy as np
-from SALib.sample.latin import sample as latin_sample # For generating base correlated samples
-from SALib.util importดูเพิ่มเติม
-from SALib.sample.latin import sample as latin_sample # For generating base correlated samples
+from SALib.sample.latin import sample as latin_sample  # For generating base correlated samples
 # (already present) from SALib.util import ProblemSpec # Not directly needed, problem is dict
 
 


### PR DESCRIPTION
## Summary
- clean up `sobol_correlated.py` by removing an invalid import line
- keep single import of `latin_sample`

## Testing
- `python - <<'EOF'
import importlib
spec = importlib.util.spec_from_file_location('sobol_correlated', 'src/SALib/sample/sobol_correlated.py')
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)
print('Import success:', module.__name__)
EOF`
- `pytest tests/sample/test_sobol_correlated.py --collect-only`
- `pytest --collect-only` *(fails: SyntaxError in tests/plotting/test_interactive_plots.py)*

------
https://chatgpt.com/codex/tasks/task_e_6868551f81e8833181281d71fe5adf7e