### PR TITLE
Fix correlated Sobol example link

### DIFF
--- a/docs/user_guide/correlated_sobol.rst
+++ b/docs/user_guide/correlated_sobol.rst
@@ -134,8 +134,4 @@ Always complement these quantitative indices with qualitative understanding of y
 Example
 -------
 
-For a practical demonstration of how to use this method and interpret its results with the Ishigami function, please see the example script:
-:ref:`ishigami_correlated_example` (TODO: Add a proper Sphinx reference or link if sphinx-gallery is used, for now, path below)
-
-The script can be found in the SALib examples directory:
-`examples/sobol_correlated_experimental/ishigami_correlated_example.py`
+For a practical demonstration of how to use this method and interpret its results with the Ishigami function, see the example script `ishigami_correlated_example.py <https://github.com/SALib/SALib/blob/main/examples/sobol_correlated_experimental/ishigami_correlated_example.py>`_.


### PR DESCRIPTION
## Summary
- fix the example link for correlated Sobol documentation

## Testing
- `make -C docs html`
- `pytest -q` *(fails: invalid syntax in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68685503bd288331b86b68c1be3bf5e9